### PR TITLE
Replace deprecated ephemeral option with MessageFlags.Ephemeral

### DIFF
--- a/src/services/channel-summary/ReportGenerator.ts
+++ b/src/services/channel-summary/ReportGenerator.ts
@@ -6,6 +6,7 @@ import {
   User,
   ChatInputCommandInteraction,
   GuildTextBasedChannel,
+  MessageFlags,
 } from "discord.js";
 import {
   getDiscussion,
@@ -74,7 +75,7 @@ export class ReportGenerator {
       return await interaction.reply({
         content:
           "In order to maintain order, please limit summary reports to last 24 hours",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 

--- a/src/services/event-notifications/setSubscriptions.ts
+++ b/src/services/event-notifications/setSubscriptions.ts
@@ -1,4 +1,4 @@
-import { BaseInteraction, EmbedBuilder } from "discord.js";
+import { BaseInteraction, EmbedBuilder, MessageFlags } from "discord.js";
 import { User } from "../../providers/db/models/User";
 
 export async function setSubscriptions(
@@ -35,7 +35,7 @@ export async function setSubscriptions(
       return await interaction.reply({
         content:
           "No parameters set, so no changes to your notificatin subscription settings.",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
@@ -68,14 +68,14 @@ export async function setSubscriptions(
 
       return await interaction.reply({
         embeds: [embed],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     } catch (err) {
       console.error(err);
       return await interaction.reply({
         content:
           "Something went wrong setting your subscriptions. Please let Jake know!",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
   }

--- a/src/services/ndb2/add-bet/index.ts
+++ b/src/services/ndb2/add-bet/index.ts
@@ -1,4 +1,4 @@
-import { userMention } from "discord.js";
+import { MessageFlags, userMention } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import * as API_V2 from "@offnominal/ndb2-api-types/v2";
@@ -43,7 +43,7 @@ export default function AddBet({ ndb2Bot, ndb2Client }: Providers) {
       );
 
       interaction.reply({
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         content: `There was an error submitting the bet to NDB2. ${userError}`,
       });
       logger.sendLog(interaction.client);
@@ -54,7 +54,7 @@ export default function AddBet({ ndb2Bot, ndb2Client }: Providers) {
     try {
       interaction.reply({
         content: `Prediction #${predictionId} successfully ${command.toLowerCase()}d!`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/add-prediction/index.ts
+++ b/src/services/ndb2/add-prediction/index.ts
@@ -3,6 +3,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
   Message,
+  MessageFlags,
   ModalBuilder,
   TextInputBuilder,
   TextInputStyle,
@@ -66,7 +67,7 @@ export default function AddPrediction({
       ),
     ];
 
-    interaction.reply({ content, components, ephemeral: true });
+    interaction.reply({ content, components, flags: MessageFlags.Ephemeral });
   });
 
   // Handles request for new prediction modal
@@ -159,7 +160,7 @@ export default function AddPrediction({
     if (!text || !driverDateString) {
       interaction.reply({
         content: `You must provide both a prediction and a due date.`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -174,7 +175,7 @@ export default function AddPrediction({
       logger.sendLog(interaction.client);
       interaction.reply({
         content: `Your due date format was invalid. Ensure it is entered as YYYY-MM-DD. If you need to re-enter your prediction, you can copy and paste it from here:\n\n${text}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -206,7 +207,7 @@ export default function AddPrediction({
       logger.sendLog(interaction.client);
       interaction.reply({
         content: `Your due date is in the past. Please adjust your date and try again. If you need to reneter your prediction, you can copy and paste it from here:\n\n${text}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -237,7 +238,7 @@ export default function AddPrediction({
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -246,7 +247,7 @@ export default function AddPrediction({
 
       const [userError, logError] = err;
       interaction.reply({
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         content: `There was an error submitting the prediction to NDB2. ${userError}`,
       });
       logger.addLog(

--- a/src/services/ndb2/add-snooze-vote/index.ts
+++ b/src/services/ndb2/add-snooze-vote/index.ts
@@ -1,4 +1,4 @@
-import { userMention } from "discord.js";
+import { MessageFlags, userMention } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import * as NDB2API from "@offnominal/ndb2-api-types/v2";
@@ -84,7 +84,7 @@ export default function AddSnoozeVote({ ndb2Bot, ndb2Client }: Providers) {
       );
 
       interaction.reply({
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         content: `There was an error submitting the Snooze Vote to NDB2. ${userError}`,
       });
       logger.sendLog(interaction.client);
@@ -95,7 +95,7 @@ export default function AddSnoozeVote({ ndb2Bot, ndb2Client }: Providers) {
     try {
       interaction.reply({
         content: `Prediction #${predictionId} Snooze Vote successfully updated!`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/add-vote/index.ts
+++ b/src/services/ndb2/add-vote/index.ts
@@ -1,4 +1,4 @@
-import { userMention } from "discord.js";
+import { MessageFlags, userMention } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 
@@ -44,7 +44,7 @@ export default function AddVote({ ndb2Bot, ndb2Client }: Providers) {
       );
 
       interaction.reply({
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         content: `There was an error submitting the vote to NDB2. ${userError}`,
       });
       logger.sendLog(interaction.client);
@@ -56,7 +56,7 @@ export default function AddVote({ ndb2Bot, ndb2Client }: Providers) {
       const pastTense = command === "Affirm" ? "affirmed" : "negated";
       interaction.reply({
         content: `Prediction #${predictionId} successfully ${pastTense}!`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/index.ts
+++ b/src/services/ndb2/index.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../logger/Logger";
 import { Providers } from "../../providers";
 import createWebooksRouter from "./webhooks";
@@ -51,7 +52,7 @@ export default function NDB2(providers: Providers) {
 
       interaction.reply({
         content: "Invalid Command. Try `/predict help` to see how I work.",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
   });

--- a/src/services/ndb2/search-predictions/index.ts
+++ b/src/services/ndb2/search-predictions/index.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import type { Endpoints } from "@offnominal/ndb2-api-types/v2";
@@ -52,7 +53,7 @@ export default function SearchPredictions({ ndb2Client, ndb2Bot }: Providers) {
       await interaction.reply({
         embeds,
         components,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/snooze-prediction/index.ts
+++ b/src/services/ndb2/snooze-prediction/index.ts
@@ -1,4 +1,5 @@
 import { isAfter, isPast } from "date-fns";
+import { MessageFlags } from "discord.js";
 import { Logger, LogInitiator, LogStatus } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import { validateUserDateInput } from "../helpers/validateUserDateInput";
@@ -47,7 +48,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -64,7 +65,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
 
       interaction.reply({
         content: `There was an error fetching this prediction. ${userError}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -80,7 +81,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
 
       interaction.reply({
         content: `Only the predictor can snooze a prediction proactively.`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
 
       return logger.sendLog(ndb2Bot);
@@ -95,7 +96,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
 
       interaction.reply({
         content: `Only open predictions can be snoozed.`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
 
       return logger.sendLog(ndb2Bot);
@@ -108,7 +109,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
     if (!isCheckDateValid) {
       interaction.reply({
         content: `Your check date format was invalid. Ensure it is entered as YYYY-MM-DD.`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.WARNING,
@@ -125,7 +126,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
       interaction.reply({
         content:
           "Your Check date is in the past. Please try again with a date in the future.",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.WARNING,
@@ -140,7 +141,7 @@ export default function SnoozePrediction({ ndb2Client, ndb2Bot }: Providers) {
       interaction.reply({
         content:
           "Your Check date is before the prediction was created. Please try again with a later date. If you are trying to trigger this prediction, use the appropriate trigger commands.",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.WARNING,

--- a/src/services/ndb2/trigger-prediction/index.ts
+++ b/src/services/ndb2/trigger-prediction/index.ts
@@ -6,6 +6,7 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  MessageFlags,
   TimestampStyles,
   bold,
   channelMention,
@@ -59,7 +60,7 @@ export default function TriggerPrediction({
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -76,7 +77,7 @@ export default function TriggerPrediction({
 
       return interaction.reply({
         content: `There was an error fetching this prediction. ${userError}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
@@ -93,7 +94,7 @@ export default function TriggerPrediction({
       if (!isDueDateValid) {
         interaction.reply({
           content: `Your close date format was invalid. Ensure it is entered as YYYY-MM-DD.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         logger.addLog(
           LogStatus.WARNING,
@@ -110,7 +111,7 @@ export default function TriggerPrediction({
         interaction.reply({
           content:
             "Your close date is in the future. Either leave it blank to trigger effective now, or put in a past date.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         logger.addLog(
           LogStatus.WARNING,
@@ -126,7 +127,7 @@ export default function TriggerPrediction({
           content: `Your close date is before the prediction's creation date, which can't happen. Either leave it blank to trigger effective now, or put in a date after ${time(
             new Date(prediction.created_date)
           )}.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         logger.addLog(
           LogStatus.WARNING,
@@ -193,7 +194,7 @@ export default function TriggerPrediction({
         });
     }, 600000);
 
-    interaction.reply({ content, components, ephemeral: true });
+    interaction.reply({ content, components, flags: MessageFlags.Ephemeral });
 
     logger.sendLog(interaction.client);
   });
@@ -233,7 +234,7 @@ export default function TriggerPrediction({
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -244,7 +245,7 @@ export default function TriggerPrediction({
 
       interaction.reply({
         content: `There was an error fetching the prediction for this retirement. ${userError}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.WARNING,
@@ -284,7 +285,7 @@ export default function TriggerPrediction({
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -295,7 +296,7 @@ export default function TriggerPrediction({
 
       interaction.reply({
         content: `Triggering this prediction failed. ${userError}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
 
       logger.addLog(

--- a/src/services/ndb2/view-details/index.ts
+++ b/src/services/ndb2/view-details/index.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import { generateInteractionReplyFromTemplate } from "../actions/embedGenerators/templates";
@@ -30,7 +31,7 @@ export default function ViewDetails({ ndb2Client, ndb2Bot }: Providers) {
       logger.addLog(LogStatus.SUCCESS, "Prediction successfully fetched");
     } catch ([userError, logError]) {
       interaction.reply({
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         content: `There was an error fetching this subscription detail. ${userError}`,
       });
       logger.addLog(
@@ -55,7 +56,7 @@ export default function ViewDetails({ ndb2Client, ndb2Bot }: Providers) {
       interaction.reply({
         embeds,
         components,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/view-leaderboards/index.ts
+++ b/src/services/ndb2/view-leaderboards/index.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import { NDB2API } from "../../../providers/ndb2-client";
@@ -38,7 +39,9 @@ export default function ViewLeaderboards({ ndb2Bot, ndb2Client }: Providers) {
 
     // Leaderboard calculcations can sometimes take time, this deferred reply let's discord know we're working on it!
     try {
-      await interaction.deferReply({ ephemeral: !brag });
+      await interaction.deferReply(
+        brag ? {} : { flags: MessageFlags.Ephemeral }
+      );
       logger.addLog(LogStatus.SUCCESS, "Successfully deferred reply.");
     } catch (err) {
       logger.addLog(LogStatus.FAILURE, "Failed to defer reply, aborting.");

--- a/src/services/ndb2/view-prediction/index.ts
+++ b/src/services/ndb2/view-prediction/index.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from "discord.js";
+import { GuildMember, MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import { API } from "../../../providers/db/models/types";
@@ -54,7 +54,7 @@ export default function ViewPrediction({
 
         interaction.reply({
           content: `There was an error fetching this prediction. Could not parse error.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
 
         logger.sendLog(interaction.client);
@@ -71,7 +71,7 @@ export default function ViewPrediction({
 
       interaction.reply({
         content: `There was an error fetching this prediction. ${userError}`,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }

--- a/src/services/ndb2/view-predictions/index.ts
+++ b/src/services/ndb2/view-predictions/index.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
 import type { Endpoints } from "@offnominal/ndb2-api-types/v2";
@@ -99,7 +100,7 @@ export default function ViewPredictions({ ndb2Client, ndb2Bot }: Providers) {
       await interaction.reply({
         embeds,
         components,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       logger.addLog(
         LogStatus.SUCCESS,

--- a/src/services/ndb2/view-score/index.ts
+++ b/src/services/ndb2/view-score/index.ts
@@ -1,4 +1,9 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+} from "discord.js";
 import fetchGuild from "../../../helpers/fetchGuild";
 import { LogInitiator, LogStatus, Logger } from "../../../logger/Logger";
 import { Providers } from "../../../providers";
@@ -39,7 +44,9 @@ export default function ViewScore({ ndb2Client, ndb2Bot }: Providers) {
 
     // Score calculcations can sometimes take time, this deferred reply let's discord know we're working on it!
     try {
-      await interaction.deferReply({ ephemeral: !brag });
+      await interaction.deferReply(
+        brag ? {} : { flags: MessageFlags.Ephemeral }
+      );
       logger.addLog(LogStatus.SUCCESS, "Successfully deferred reply.");
     } catch (err) {
       logger.addLog(LogStatus.FAILURE, "Failed to defer reply, aborting.");

--- a/src/services/post-news/list-rss-feeds.ts
+++ b/src/services/post-news/list-rss-feeds.ts
@@ -1,5 +1,5 @@
 import { SanityClient } from "@sanity/client";
-import { EmbedBuilder, Interaction } from "discord.js";
+import { EmbedBuilder, Interaction, MessageFlags } from "discord.js";
 import { NewsCategoryDocument } from "../../providers/sanity";
 import mcconfig from "../../mcconfig";
 
@@ -31,7 +31,7 @@ export function listRSSFeeds(interaction: Interaction, client: SanityClient) {
         fields: feedsFields,
       });
 
-      return interaction.reply({ embeds: [embed], ephemeral: true });
+      return interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
     })
     .catch((err) => console.error(err));
 }

--- a/src/services/send-help/ndb2Bot.ts
+++ b/src/services/send-help/ndb2Bot.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Interaction } from "discord.js";
+import { EmbedBuilder, Interaction, MessageFlags } from "discord.js";
 
 export function sendNdb2Help(interaction: Interaction) {
   if (!interaction.isChatInputCommand()) return;
@@ -58,5 +58,5 @@ export function sendNdb2Help(interaction: Interaction) {
     ],
   });
 
-  interaction.reply({ embeds: [embed], ephemeral: true });
+  interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
 }

--- a/src/services/stream-host/ManagedStream.ts
+++ b/src/services/stream-host/ManagedStream.ts
@@ -5,6 +5,7 @@ import {
   GuildScheduledEvent,
   GuildScheduledEventStatus,
   MessageCreateOptions,
+  MessageFlags,
   MessagePayload,
   ThreadChannel,
 } from "discord.js";
@@ -137,7 +138,7 @@ export class ManagedStream extends EventEmitter {
       try {
         await interaction.reply({
           content: `This command only works during a live Off-Nominal episode stream.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       } catch (err) {
         console.error(err);
@@ -177,7 +178,7 @@ export class ManagedStream extends EventEmitter {
       try {
         await interaction.reply({
           content: `This command only works during a live Off-Nominal episode stream.`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       } catch (err) {
         console.error(err);
@@ -196,7 +197,7 @@ export class ManagedStream extends EventEmitter {
             )
           ),
         ],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates all Discord interaction responses that used the deprecated `ephemeral: true` option to `flags: MessageFlags.Ephemeral` from `discord.js`, matching current API guidance and removing the Node deprecation warning.

For `deferReply` when visibility depends on the `brag` option (score and leaderboards), the code now passes `{ flags: MessageFlags.Ephemeral }` when the reply should be private and `{}` when bragging (public), preserving prior behavior.

## Testing

- `npx tsc --noEmit` passes.

Note: `npm run build` runs slash command registration and fails without Discord credentials in this environment; compilation succeeded before that step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d52e9fe-da7c-4164-9d0f-c1175ed92780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d52e9fe-da7c-4164-9d0f-c1175ed92780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

