### PR TITLE
Fix Shunt source embed target channel

### DIFF
--- a/src/services/shunt/shunt.ts
+++ b/src/services/shunt/shunt.ts
@@ -176,8 +176,8 @@ export default async function shunt(
       embeds: [
         generateEmbed({
           url: destinationMessage.url,
-          sourceChannelName: targetChannel.name,
-          targetChannelName: sourceChannel.name,
+          sourceChannelName: sourceChannel.name,
+          targetChannelName: targetChannel.name,
           shunterName,
           topic,
           direction: "outbound",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct the outbound Shunt embed generated after posting the destination message so the source channel displays the target channel name.

## Testing
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-469c0c13-12ba-48f2-a85e-1ab33220408e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-469c0c13-12ba-48f2-a85e-1ab33220408e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Off-Nominal/codesmith/mission-control/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->