### PR TITLE
Fix event-driven trigger notice original check date

### DIFF
--- a/src/services/ndb2/actions/embedGenerators/templates/trigger_notice.ts
+++ b/src/services/ndb2/actions/embedGenerators/templates/trigger_notice.ts
@@ -21,6 +21,7 @@ export const generateTriggerNoticeEmbed = (
 ): BaseMessageOptions["embeds"] => {
   const created = new Date(props.prediction.created_date);
   const due = new Date(props.prediction.due_date || 0);
+  const check = new Date(props.prediction.check_date || 0);
   const triggered = new Date(props.prediction.triggered_date || 0);
   const closed = new Date(props.prediction.closed_date || 0);
 
@@ -63,7 +64,13 @@ export const generateTriggerNoticeEmbed = (
     embedFields.date(created, "Created", { context: props.context }),
   ];
 
-  props.triggerer && fields.push(embedFields.date(due, "Original Due Date"));
+  if (props.triggerer) {
+    if (props.prediction.driver === "date") {
+      fields.push(embedFields.date(due, "Original Due Date"));
+    } else {
+      fields.push(embedFields.date(check, "Original Check Date"));
+    }
+  }
 
   fields.push(embedFields.date(triggered, "Triggered Date"));
   fields.push(embedFields.date(closed, "Effective Close Date"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update NDB2 trigger notice embeds to display the original check date for event-driven predictions
- Keep date-driven trigger notices displaying the original due date

## Testing
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0450960-9b2c-4f12-ac52-2a42963ccf21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0450960-9b2c-4f12-ac52-2a42963ccf21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Off-Nominal/codesmith/mission-control/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782692253&installation_id=132360161&pr_number=386&repository=Off-Nominal%2Fmission-control&return_to=https%3A%2F%2Fgithub.com%2FOff-Nominal%2Fmission-control%2Fpull%2F386&signature=3f5d5161df7f1cfc086a40b6c472cbb69690ef5dced174c80a9a060efc4d2829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->