### PR TITLE
Connect Discord bots in background with session rate-limit retry

### DIFF
--- a/src/helpers/discord-client-connect.ts
+++ b/src/helpers/discord-client-connect.ts
@@ -1,0 +1,53 @@
+import type { Client } from "discord.js";
+import {
+  discordSessionRateLimitDelayMs,
+  isDiscordSessionRateLimitError,
+} from "./discord-session-rate-limit";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const stopConnect = new WeakMap<Client, boolean>();
+
+export function connectDiscordClientInBackground(
+  client: Client,
+  token: string,
+  label: string,
+): void {
+  stopConnect.set(client, false);
+  void (async () => {
+    let attempt = 0;
+    while (!client.isReady() && !stopConnect.get(client)) {
+      attempt += 1;
+      try {
+        if (attempt === 1) {
+          console.log(`[Discord/${label}] Connecting in background…`);
+        } else {
+          console.log(`[Discord/${label}] Retrying gateway connection (attempt ${attempt})…`);
+        }
+        await client.login(token);
+        console.log(`[Discord/${label}] Gateway connected`);
+        return;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const rateLimitDelayMs = discordSessionRateLimitDelayMs(err);
+        const delayMs = rateLimitDelayMs ?? Math.min(1_000 * 2 ** Math.min(attempt, 5), 30_000);
+        if (isDiscordSessionRateLimitError(err)) {
+          console.error(`[Discord/${label}] Session rate limited; retrying in ${Math.ceil(delayMs / 1000)}s: ${message}`);
+        } else {
+          console.error(`[Discord/${label}] Login failed: ${message}`);
+        }
+        await sleep(delayMs);
+      }
+    }
+  })();
+}
+
+export function stopDiscordClientConnect(client: Client): void {
+  stopConnect.set(client, true);
+}
+
+export function isDiscordClientReady(client: Client): boolean {
+  return client.isReady();
+}

--- a/src/helpers/discord-session-rate-limit.ts
+++ b/src/helpers/discord-session-rate-limit.ts
@@ -1,0 +1,22 @@
+const SESSION_RESET_AT_RE =
+  /resets at (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/i;
+
+export function isDiscordSessionRateLimitError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.message.includes("Not enough sessions remaining")
+  );
+}
+
+export function discordSessionRateLimitDelayMs(
+  err: unknown,
+  nowMs: number = Date.now(),
+): number | null {
+  if (!isDiscordSessionRateLimitError(err)) return null;
+  if (!(err instanceof Error)) return null;
+  const match = err.message.match(SESSION_RESET_AT_RE);
+  if (!match) return null;
+  const resetAtMs = Date.parse(match[1]);
+  if (Number.isNaN(resetAtMs)) return null;
+  return Math.max(1_000, resetAtMs - nowMs + 1_000);
+}

--- a/src/providers/content-bot/index.ts
+++ b/src/providers/content-bot/index.ts
@@ -2,6 +2,7 @@ import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
 import mcconfig from "../../mcconfig";
 import { Client } from "discord.js";
+import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 const contentBot = new Client({
   intents: mcconfig.discord.clients.content.intents,
@@ -13,6 +14,6 @@ contentBot.once("clientReady", () => {
   bootLogger.logItemSuccess("contentBot");
 });
 
-contentBot.login(mcconfig.discord.clients.content.token);
+connectDiscordClientInBackground(contentBot, mcconfig.discord.clients.content.token, "content");
 
 export default contentBot;

--- a/src/providers/events-bot/index.ts
+++ b/src/providers/events-bot/index.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
+import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 const eventsBot = new Client({
   intents: [mcconfig.discord.clients.events.intents],
@@ -14,6 +15,6 @@ eventsBot.once("clientReady", () => {
   bootLogger.logItemSuccess("eventsBot");
 });
 
-eventsBot.login(mcconfig.discord.clients.events.token);
+connectDiscordClientInBackground(eventsBot, mcconfig.discord.clients.events.token, "events");
 
 export default eventsBot;

--- a/src/providers/helper-bot/index.ts
+++ b/src/providers/helper-bot/index.ts
@@ -3,6 +3,7 @@ import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import fetchGuild from "../../helpers/fetchGuild";
 import { LogStatus } from "../../logger/Logger";
+import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 export enum HelperBotEvents {
   SUMMARY_CREATE = "summaryReportCreate",
@@ -39,6 +40,6 @@ helperBot.once("clientReady", () => {
   bootLogger.logItemSuccess("helperBot");
 });
 
-helperBot.login(mcconfig.discord.clients.helper.token);
+connectDiscordClientInBackground(helperBot, mcconfig.discord.clients.helper.token, "helper");
 
 export default helperBot;

--- a/src/providers/ndb2-bot/index.ts
+++ b/src/providers/ndb2-bot/index.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
+import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 export enum Ndb2Events {
   NEW_PREDICTION = "new_prediction",
@@ -31,6 +32,6 @@ ndb2Bot.once("clientReady", () => {
 // Ndb2 is busy, so we need to increase the max listeners
 ndb2Bot.setMaxListeners(20);
 
-ndb2Bot.login(mcconfig.discord.clients.ndb2.token);
+connectDiscordClientInBackground(ndb2Bot, mcconfig.discord.clients.ndb2.token, "ndb2");
 
 export default ndb2Bot;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors [Off-Nominal/ndb2#164](https://github.com/Off-Nominal/ndb2/pull/164).

During Coolify deploy loops, mission-control was crashing because four bot providers called `client.login(token)` at module import with no `.catch()`. Failed logins became unhandled promise rejections. When ndb2 API and mission-control share the same bot token, simultaneous restarts can exhaust Discord's IDENTIFY session budget.

This PR fixes the login pattern only — Express `/health` and boot flow are unchanged.

## Changes

- **`src/helpers/discord-session-rate-limit.ts`** — Detects Discord session rate-limit errors and parses the reset timestamp from the error message.
- **`src/helpers/discord-client-connect.ts`** — `connectDiscordClientInBackground()` retries login in a background loop with session-rate-limit-aware delays or exponential backoff.
- **All four bot providers updated** (`ndb2`, `helper`, `content`, `events`) to use background connect instead of bare `client.login()`.

Existing `clientReady` handlers, `bootLogger.logItemSuccess(...)`, and `client.on("error", console.error)` are unchanged.

## Expected behavior after deploy

```
[Discord/ndb2] Connecting in background…
[Discord/ndb2] Session rate limited; retrying in 3074s: Not enough sessions remaining…
[Discord/ndb2] Gateway connected
```

Express stays up while bots reconnect in the background.

## Verification

- `npm install`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Off-Nominal/codesmith/mission-control/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786272212&installation_id=132360161&pr_number=388&repository=Off-Nominal%2Fmission-control&return_to=https%3A%2F%2Fgithub.com%2FOff-Nominal%2Fmission-control%2Fpull%2F388&signature=317e318938ed4fd4dc252a2e9f9bb8218f166ff7bdebc43a93d66e105ce5b385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->