### PR TITLE
Connect Discord bots in background with session rate-limit retry

### DIFF
--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -64,6 +64,10 @@ export class Logger {
   }
 
   public async sendLog(client: Client) {
+    if (!client.isReady()) {
+      return;
+    }
+
     const embed = this.generateEmbed();
 
     try {

--- a/src/services/launch-events/index.ts
+++ b/src/services/launch-events/index.ts
@@ -10,7 +10,17 @@ export default function LaunchEvents({
   mcconfig,
 }: Providers) {
   const sync = (eventType: "new" | "change" | "ready") => {
-    syncEvents(rllWatcher.launches, eventsBot, eventType);
+    const run = () => {
+      void syncEvents(rllWatcher.launches, eventsBot, eventType).catch((err) => {
+        console.error(`[LaunchEvents] Sync failed (${eventType}):`, err);
+      });
+    };
+
+    if (eventsBot.isReady()) {
+      run();
+    } else {
+      eventsBot.once("clientReady", run);
+    }
   };
 
   rllWatcher.on("ready", () => sync("ready"));

--- a/src/services/launch-events/syncLaunches.ts
+++ b/src/services/launch-events/syncLaunches.ts
@@ -80,7 +80,7 @@ export async function syncEvents(
   } catch (err) {
     logger.addLog(LogStatus.FAILURE, "Could not fetch Guild.");
     logger.sendLog(eventsBot);
-    return Promise.reject("Guild not found");
+    return;
   }
 
   const eventsManager = guild.scheduledEvents;
@@ -100,7 +100,7 @@ export async function syncEvents(
   } catch (err) {
     logger.addLog(LogStatus.FAILURE, "Could not fetch Events.");
     logger.sendLog(eventsBot);
-    return Promise.reject();
+    return;
   }
 
   const counts = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors [Off-Nominal/ndb2#164](https://github.com/Off-Nominal/ndb2/pull/164).

During Coolify deploy loops, mission-control was crashing because four bot providers called `client.login(token)` at module import with no `.catch()`. Failed logins became unhandled promise rejections. When ndb2 API and mission-control share the same bot token, simultaneous restarts can exhaust Discord's IDENTIFY session budget.

## Changes

- **`src/helpers/discord-session-rate-limit.ts`** — Detects Discord session rate-limit errors and parses the reset timestamp from the error message.
- **`src/helpers/discord-client-connect.ts`** — `connectDiscordClientInBackground()` retries login in a background loop with session-rate-limit-aware delays or exponential backoff.
- **All four bot providers updated** (`ndb2`, `helper`, `content`, `events`) to use background connect instead of bare `client.login()`.

### Follow-up boot crash fix

Background connect exposed two other startup paths that assumed Discord was already logged in:

- **`Logger.sendLog`** — no-ops when the client is not `isReady()` (avoids "Expected token to be set" during the 15s boot checklist window).
- **`LaunchEvents`** — defers RLL sync until `eventsBot` fires `clientReady`; adds `.catch()` on sync.
- **`syncLaunches`** — returns early instead of `Promise.reject("Guild not found")` when the guild is unavailable.

Express `/health` and boot checklist logic are unchanged. Process no longer exits on `ERR_UNHANDLED_REJECTION` during session rate limits.

## Expected behavior after deploy

```
[Discord/ndb2] Connecting in background…
[Discord/ndb2] Session rate limited; retrying in 3074s: Not enough sessions remaining…
[Discord/ndb2] Gateway connected
```

Express stays up while bots reconnect in the background.

## Verification

- `npm install`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Off-Nominal/codesmith/mission-control/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786272649&installation_id=132360161&pr_number=389&repository=Off-Nominal%2Fmission-control&return_to=https%3A%2F%2Fgithub.com%2FOff-Nominal%2Fmission-control%2Fpull%2F389&signature=003732525ccc4576a341cf8220da54e4bda831f583739919292ae9b0e6bf717f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->