### PR TITLE
Make Discord bots a blocking boot dependency with health signaling

### DIFF
--- a/src/helpers/discord-boot-status.ts
+++ b/src/helpers/discord-boot-status.ts
@@ -1,0 +1,92 @@
+import type { Client } from "discord.js";
+
+export type DiscordBotLabel = "ndb2" | "helper" | "content" | "events";
+
+export type DiscordBotConnectionStatus =
+  | "pending"
+  | "connecting"
+  | "rate_limited"
+  | "connected"
+  | "disconnected"
+  | "failed";
+
+export type DiscordBotStatus = {
+  label: DiscordBotLabel;
+  status: DiscordBotConnectionStatus;
+  message?: string;
+  retryAt?: string;
+  retryInSec?: number;
+};
+
+const DISCORD_BOT_LABELS: DiscordBotLabel[] = [
+  "ndb2",
+  "helper",
+  "content",
+  "events",
+];
+
+const statuses = new Map<DiscordBotLabel, DiscordBotStatus>();
+const clients = new Map<DiscordBotLabel, Client>();
+
+export function initDiscordBootStatus(): void {
+  for (const label of DISCORD_BOT_LABELS) {
+    statuses.set(label, { label, status: "pending" });
+  }
+}
+
+export function registerDiscordBootClient(
+  label: DiscordBotLabel,
+  client: Client,
+): void {
+  clients.set(label, client);
+}
+
+export function setDiscordBotStatus(
+  label: DiscordBotLabel,
+  update: Partial<Omit<DiscordBotStatus, "label">>,
+): void {
+  const current = statuses.get(label) ?? { label, status: "pending" };
+  statuses.set(label, { ...current, ...update, label });
+}
+
+function liveStatus(label: DiscordBotLabel): DiscordBotStatus {
+  const recorded = statuses.get(label) ?? { label, status: "pending" };
+  const client = clients.get(label);
+
+  if (client?.isReady()) {
+    return { ...recorded, label, status: "connected" };
+  }
+
+  if (
+    recorded.status === "connected" ||
+    recorded.status === "disconnected"
+  ) {
+    return { ...recorded, label, status: "disconnected" };
+  }
+
+  return recorded;
+}
+
+export function getDiscordBootStatus() {
+  const bots = DISCORD_BOT_LABELS.map((label) => liveStatus(label));
+  const allReady = bots.every((bot) => bot.status === "connected");
+  const anyRateLimited = bots.some((bot) => bot.status === "rate_limited");
+
+  const waiting = bots
+    .filter((bot) => bot.status !== "connected")
+    .map((bot) => `${bot.label} (${bot.status})`);
+
+  let summary: string;
+  if (allReady) {
+    summary = "All Discord gateway clients connected";
+  } else if (anyRateLimited) {
+    const limited = bots
+      .filter((bot) => bot.status === "rate_limited")
+      .map((bot) => bot.label);
+    summary = `Discord session rate limited: ${limited.join(", ")}`;
+  } else {
+    summary = `Waiting for Discord gateway clients: ${waiting.join(", ")}`;
+  }
+
+  return { allReady, anyRateLimited, bots, summary };
+}

--- a/src/helpers/discord-client-connect.ts
+++ b/src/helpers/discord-client-connect.ts
@@ -1,16 +1,29 @@
 import { Status, type Client } from "discord.js";
 import {
+  type DiscordBotLabel,
+  getDiscordBootStatus,
+  registerDiscordBootClient,
+  setDiscordBotStatus,
+} from "./discord-boot-status";
+import {
   discordSessionRateLimitDelayMs,
   isDiscordSessionRateLimitError,
 } from "./discord-session-rate-limit";
+
+export { getDiscordBootStatus } from "./discord-boot-status";
+export type {
+  DiscordBotLabel,
+  DiscordBotStatus,
+} from "./discord-boot-status";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const stopConnect = new WeakMap<Client, boolean>();
-const connectLoopRunning = new WeakMap<Client, boolean>();
-const hasConnected = new WeakMap<Client, boolean>();
+
+const SESSION_RESET_AT_RE =
+  /resets at (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/i;
 
 function isDiscordClientConnecting(client: Client): boolean {
   const status = client.ws.status;
@@ -47,70 +60,112 @@ function waitForClientReady(
   });
 }
 
-export function connectDiscordClientInBackground(
+export type DiscordBotConnectConfig = {
+  client: Client;
+  token: string;
+  label: DiscordBotLabel;
+};
+
+export async function connectDiscordClient(
   client: Client,
   token: string,
-  label: string,
-): void {
-  if (client.isReady() || connectLoopRunning.get(client) || hasConnected.get(client)) {
+  label: DiscordBotLabel,
+): Promise<void> {
+  registerDiscordBootClient(label, client);
+  stopConnect.set(client, false);
+
+  if (client.isReady()) {
+    setDiscordBotStatus(label, { status: "connected" });
+    console.log(`[Discord/${label}] Gateway already connected`);
     return;
   }
 
-  connectLoopRunning.set(client, true);
-  stopConnect.set(client, false);
+  let attempt = 0;
 
-  void (async () => {
-    let attempt = 0;
+  while (!client.isReady() && !stopConnect.get(client)) {
+    attempt += 1;
 
     try {
-      while (!client.isReady() && !stopConnect.get(client)) {
-        if (hasConnected.get(client)) {
-          return;
-        }
-
-        attempt += 1;
-
-        try {
-          if (attempt === 1) {
-            console.log(`[Discord/${label}] Connecting in background…`);
-          } else {
-            console.log(
-              `[Discord/${label}] Retrying gateway connection (attempt ${attempt})…`,
-            );
-          }
-
-          if (isDiscordClientConnecting(client)) {
-            await waitForClientReady(client);
-            continue;
-          }
-
-          await client.login(token);
-          await waitForClientReady(client);
-          hasConnected.set(client, true);
-          console.log(`[Discord/${label}] Gateway connected`);
-          return;
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          const rateLimitDelayMs = discordSessionRateLimitDelayMs(err);
-          const delayMs =
-            rateLimitDelayMs ??
-            Math.min(1_000 * 2 ** Math.min(attempt, 5), 30_000);
-
-          if (isDiscordSessionRateLimitError(err)) {
-            console.error(
-              `[Discord/${label}] Session rate limited; retrying in ${Math.ceil(delayMs / 1000)}s: ${message}`,
-            );
-          } else {
-            console.error(`[Discord/${label}] Login failed: ${message}`);
-          }
-
-          await sleep(delayMs);
-        }
+      if (attempt === 1) {
+        console.log(`[Discord/${label}] Connecting…`);
+      } else {
+        console.log(
+          `[Discord/${label}] Retrying gateway connection (attempt ${attempt})…`,
+        );
       }
-    } finally {
-      connectLoopRunning.set(client, false);
+
+      setDiscordBotStatus(label, { status: "connecting" });
+
+      if (isDiscordClientConnecting(client)) {
+        await waitForClientReady(client);
+        continue;
+      }
+
+      await client.login(token);
+      await waitForClientReady(client);
+      setDiscordBotStatus(label, { status: "connected" });
+      console.log(`[Discord/${label}] Gateway connected`);
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const rateLimitDelayMs = discordSessionRateLimitDelayMs(err);
+      const delayMs =
+        rateLimitDelayMs ??
+        Math.min(1_000 * 2 ** Math.min(attempt, 5), 30_000);
+
+      if (isDiscordSessionRateLimitError(err)) {
+        const retryAt =
+          err instanceof Error
+            ? err.message.match(SESSION_RESET_AT_RE)?.[1]
+            : undefined;
+
+        setDiscordBotStatus(label, {
+          status: "rate_limited",
+          message,
+          retryAt,
+          retryInSec: Math.ceil(delayMs / 1_000),
+        });
+
+        console.error(
+          `[Discord/${label}] SESSION RATE LIMITED — /health returns 503 (Coolify can alert)`,
+        );
+        console.error(
+          `[Discord/${label}] Retrying in ${Math.ceil(delayMs / 1_000)}s: ${message}`,
+        );
+      } else {
+        setDiscordBotStatus(label, {
+          status: "failed",
+          message,
+          retryInSec: Math.ceil(delayMs / 1_000),
+        });
+        console.error(
+          `[Discord/${label}] Login failed; retrying in ${Math.ceil(delayMs / 1_000)}s: ${message}`,
+        );
+      }
+
+      await sleep(delayMs);
     }
-  })();
+  }
+
+  if (stopConnect.get(client)) {
+    throw new Error(`[Discord/${label}] Gateway connect stopped`);
+  }
+}
+
+export async function connectAllDiscordBots(
+  configs: DiscordBotConnectConfig[],
+): Promise<void> {
+  console.log(
+    "[Boot] Waiting for all Discord gateway clients (required dependency)…",
+  );
+
+  await Promise.all(
+    configs.map(({ client, token, label }) =>
+      connectDiscordClient(client, token, label),
+    ),
+  );
+
+  console.log("[Boot] All Discord gateway clients connected");
 }
 
 export function stopDiscordClientConnect(client: Client): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,13 @@ import mcconfig from "./mcconfig";
 // Boot Logger
 import bootLogger from "./logger";
 import { LogStatus } from "./logger/Logger";
-bootLogger.addLog(LogStatus.INFO, "Mission Control in Startup...");
 
 // Providers
 import { providers } from "./providers";
+
+// Discord boot
+import { connectAllDiscordBots } from "./helpers/discord-client-connect";
+import { initDiscordBootStatus } from "./helpers/discord-boot-status";
 
 // Services
 import SetDiscordClientPresence from "./services/set-discord-client-presence";
@@ -61,19 +64,58 @@ const services = [
   CreateEventFromThread,
 ];
 
-services.forEach((service) => service(providers));
+function listenApi(): Promise<void> {
+  return new Promise((resolve) => {
+    providers.api.listen(mcconfig.api.port, () => {
+      bootLogger.addLog(
+        LogStatus.SUCCESS,
+        "Express Server booted and listening.",
+      );
+      bootLogger.logItemSuccess("api");
+      console.log(
+        "[Boot] /health is live — returns 503 until all Discord bots connect",
+      );
+      resolve();
+    });
+  });
+}
 
-/***********************************
- *  API Initialization
- ************************************/
+async function main(): Promise<void> {
+  bootLogger.addLog(LogStatus.INFO, "Mission Control in Startup...");
+  initDiscordBootStatus();
 
-providers.api.listen(mcconfig.api.port, () => {
-  bootLogger.addLog(LogStatus.SUCCESS, "Express Server booted and listening.");
-  bootLogger.logItemSuccess("api");
+  await listenApi();
+
+  await connectAllDiscordBots([
+    {
+      client: providers.ndb2Bot,
+      token: mcconfig.discord.clients.ndb2.token,
+      label: "ndb2",
+    },
+    {
+      client: providers.helperBot,
+      token: mcconfig.discord.clients.helper.token,
+      label: "helper",
+    },
+    {
+      client: providers.contentBot,
+      token: mcconfig.discord.clients.content.token,
+      label: "content",
+    },
+    {
+      client: providers.eventsBot,
+      token: mcconfig.discord.clients.events.token,
+      label: "events",
+    },
+  ]);
+
+  console.log("[Boot] Discord ready — starting services");
+  services.forEach((service) => service(providers));
+
+  bootLogger.checkBoot(providers.helperBot);
+}
+
+main().catch((err) => {
+  console.error("[Boot] Fatal startup error:", err);
+  process.exit(1);
 });
-
-/***********************************
- *  Boot Logger
- ************************************/
-
-bootLogger.checkBoot(providers.helperBot);

--- a/src/providers/api/index.ts
+++ b/src/providers/api/index.ts
@@ -1,5 +1,6 @@
 import mcconfig from "../../mcconfig";
 import express from "express";
+import { getDiscordBootStatus } from "../../helpers/discord-client-connect";
 
 const api = express();
 
@@ -11,7 +12,32 @@ if (mcconfig.env !== "production") {
 }
 
 api.get("/health", (req, res) => {
-  res.status(200).send("OK");
+  const discord = getDiscordBootStatus();
+
+  const discordPayload = Object.fromEntries(
+    discord.bots.map((bot) => [
+      bot.label,
+      {
+        status: bot.status,
+        ...(bot.retryInSec !== undefined && { retryInSec: bot.retryInSec }),
+        ...(bot.retryAt && { retryAt: bot.retryAt }),
+        ...(bot.message && { message: bot.message }),
+      },
+    ]),
+  );
+
+  if (discord.allReady) {
+    return res.status(200).json({
+      status: "healthy",
+      discord: discordPayload,
+    });
+  }
+
+  return res.status(503).json({
+    status: "unhealthy",
+    reason: discord.summary,
+    discord: discordPayload,
+  });
 });
 
 api.get("*", (req, res) => res.status(404).json("Invalid Resource."));

--- a/src/providers/content-bot/index.ts
+++ b/src/providers/content-bot/index.ts
@@ -2,7 +2,6 @@ import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
 import mcconfig from "../../mcconfig";
 import { Client } from "discord.js";
-import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 const contentBot = new Client({
   intents: mcconfig.discord.clients.content.intents,
@@ -13,7 +12,5 @@ contentBot.once("clientReady", () => {
   bootLogger.addLog(LogStatus.SUCCESS, "Content Bot ready");
   bootLogger.logItemSuccess("contentBot");
 });
-
-connectDiscordClientInBackground(contentBot, mcconfig.discord.clients.content.token, "content");
 
 export default contentBot;

--- a/src/providers/events-bot/index.ts
+++ b/src/providers/events-bot/index.ts
@@ -2,7 +2,6 @@ import { Client } from "discord.js";
 import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
-import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 const eventsBot = new Client({
   intents: [mcconfig.discord.clients.events.intents],
@@ -14,7 +13,5 @@ eventsBot.once("clientReady", () => {
   bootLogger.addLog(LogStatus.SUCCESS, "Event Bot ready");
   bootLogger.logItemSuccess("eventsBot");
 });
-
-connectDiscordClientInBackground(eventsBot, mcconfig.discord.clients.events.token, "events");
 
 export default eventsBot;

--- a/src/providers/helper-bot/index.ts
+++ b/src/providers/helper-bot/index.ts
@@ -3,7 +3,6 @@ import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import fetchGuild from "../../helpers/fetchGuild";
 import { LogStatus } from "../../logger/Logger";
-import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 export enum HelperBotEvents {
   SUMMARY_CREATE = "summaryReportCreate",
@@ -39,7 +38,5 @@ helperBot.once("clientReady", () => {
   bootLogger.addLog(LogStatus.SUCCESS, "Helper Bot ready");
   bootLogger.logItemSuccess("helperBot");
 });
-
-connectDiscordClientInBackground(helperBot, mcconfig.discord.clients.helper.token, "helper");
 
 export default helperBot;

--- a/src/providers/ndb2-bot/index.ts
+++ b/src/providers/ndb2-bot/index.ts
@@ -2,7 +2,6 @@ import { Client } from "discord.js";
 import mcconfig from "../../mcconfig";
 import bootLogger from "../../logger";
 import { LogStatus } from "../../logger/Logger";
-import { connectDiscordClientInBackground } from "../../helpers/discord-client-connect";
 
 export enum Ndb2Events {
   NEW_PREDICTION = "new_prediction",
@@ -31,7 +30,5 @@ ndb2Bot.once("clientReady", () => {
 
 // Ndb2 is busy, so we need to increase the max listeners
 ndb2Bot.setMaxListeners(20);
-
-connectDiscordClientInBackground(ndb2Bot, mcconfig.discord.clients.ndb2.token, "ndb2");
 
 export default ndb2Bot;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discord bots are a core dependency — the app should not start services until all four gateway clients are connected. During session rate limits, the process keeps retrying but reports **unhealthy** so Coolify can alert via its Discord webhook.

## Boot order

1. **Express starts immediately** — `/health` is available for Coolify
2. **`connectAllDiscordBots()` blocks** — retries on session rate limits with loud console errors
3. **Services register only after all bots are `clientReady`**
4. **Boot checklist runs** as before

## Health check (`GET /health`)

**Healthy (200)** when all four bots are connected.

**Unhealthy (503)** while connecting or rate-limited — includes per-bot `status`, `retryInSec`, and `retryAt` for Coolify webhook alerts.

Health also returns 503 if a bot disconnects at runtime.

## Coolify setup

Point the container health check at `/health`. When Discord session limits hit during deploy, the container stays up but **unhealthy** — Coolify can notify Discord without relying on the bots themselves.

## Verification

- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4b9e-e518-79ec-824b-0a8bf5a93d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Off-Nominal/codesmith/mission-control/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786277695&installation_id=132360161&pr_number=392&repository=Off-Nominal%2Fmission-control&return_to=https%3A%2F%2Fgithub.com%2FOff-Nominal%2Fmission-control%2Fpull%2F392&signature=df1dbf1a2bff05cf2673d704f2557a73c40b027e05996d715162a7af87a411f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->